### PR TITLE
[Dependencies] Change to use Crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,8 @@ pkg-config = "0.3.7"
 [dependencies]
 bitflags = "0.4"
 libc = "0.2"
-
-[dependencies.gio-sys]
-git = "https://github.com/gtk-rs/sys"
-version = "0.3.1"
-
-[dependencies.glib-sys]
-git = "https://github.com/gtk-rs/sys"
-version = "0.3.1"
+gio-sys = "0.3.1"
+glib-sys = "0.3.1"
 
 [features]
 


### PR DESCRIPTION
This allows using older versions of the dependencies. When the git repo updates, that
version doesn't seem to be available.